### PR TITLE
German crash words

### DIFF
--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -56,6 +56,10 @@ spanish_fixes = {
 	re.compile(r'([a-zA-Z0-9_]+)@(\w+)'): r'\1 arroba \2',
 	re.compile(u'([€$]\d{1,3})((\s\d{3})+\.\d{2})'): r'\1 \2',
 }
+german_fixes = {
+	re.compile(r'dane-ben', re.I): r'dane- ben',
+	re.compile(r'dage-gen', re.I): r'dage- gen',
+}
 
 variants = {
 	1:"Reed",
@@ -196,6 +200,8 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		if _ibmeci.params[9] in (196609, 196608):
 			text = resub(french_fixes, text)
 			text = text.replace('quil', 'qil') #Sometimes this string make everything buggy with IBMTTS in French
+		if  _ibmeci.params[9] in ('deu',262144):
+			text = resub(german_fixes, text)
 		#this converts to ansi for anticrash. If this breaks with foreign langs, we can remove it.
 		text = text.encode(self.currentEncoding, 'replace') # special unicode symbols may encode to backquote. For this reason, backquote processing is after this.
 		if not self._backquoteVoiceTags:

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -57,6 +57,7 @@ spanish_fixes = {
 	re.compile(u'([€$]\d{1,3})((\s\d{3})+\.\d{2})'): r'\1 \2',
 }
 german_fixes = {
+# Crash words.
 	re.compile(r'dane-ben', re.I): r'dane- ben',
 	re.compile(r'dage-gen', re.I): r'dage- gen',
 }

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -200,7 +200,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		if _ibmeci.params[9] in (196609, 196608):
 			text = resub(french_fixes, text)
 			text = text.replace('quil', 'qil') #Sometimes this string make everything buggy with IBMTTS in French
-		if  _ibmeci.params[9] in ('deu',262144):
+		if  _ibmeci.params[9] in ('deu', 262144):
 			text = resub(german_fixes, text)
 		#this converts to ansi for anticrash. If this breaks with foreign langs, we can remove it.
 		text = text.encode(self.currentEncoding, 'replace') # special unicode symbols may encode to backquote. For this reason, backquote processing is after this.


### PR DESCRIPTION
This pull request adds some fixes for German crash codes. Simple text replacements for now, unfortunately I don't know German so I'm not sure if these catch false positives, but as far as I know these are the only known crash words for it, and basic testing hasn't revealed any variants.