### PR TITLE
Updated tz crash expression

### DIFF
--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -41,7 +41,7 @@ anticrash_res = {
 	re.compile(br"(re|un|non|anti)cosp", re.I): br"\1kosp",
 	#re.compile(br"(anti|non|re|un|ultra|mis|cyber|over|under)caesure", re.I): r"\1ceasure",
 	re.compile(br"(EUR[A-Z]+)(\d+)", re.I): br"\1 \2",
-	re.compile(br"\b(\d+|\W+|[A-Z]+)?t+z[s]che", re.I): r"\1tz sche"
+	re.compile(br"\b(\d+|\W+|[bcdfghjklmnpqrstvwxz]+)?t+z[s]che", re.I): br"\1tz sche"
 	}
 
 english_fixes = {


### PR DESCRIPTION
This PR updates the tz crash expression to prevent it from catching false positives such as "nietzsche". It seems that it only crashes when consonants are added as a prefix, not vowels.