### PR TITLE
New anticrash expression

### DIFF
--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -41,7 +41,8 @@ anticrash_res = {
 	re.compile(br"(re|un|non|anti)cosp", re.I): br"\1kosp",
 	#re.compile(br"(anti|non|re|un|ultra|mis|cyber|over|under)caesure", re.I): r"\1ceasure",
 	re.compile(br"(EUR[A-Z]+)(\d+)", re.I): br"\1 \2",
-	re.compile(br"\b(\d+|\W+|[bcdfghjklmnpqrstvwxz]+)?t+z[s]che", re.I): br"\1tz sche"
+	re.compile(br"\b(\d+|\W+|[bcdfghjklmnpqrstvwxz]+)?t+z[s]che", re.I): br"\1tz sche",
+	re.compile(br"(juaras|juaros|juarus|juares)a", re.I): br"\1 a"
 	}
 
 english_fixes = {


### PR DESCRIPTION
This pull request adds a new crash expression for juaras, as well as juares, juaros, and juarus. While these can cause the synth to make fun noises, they can also crash it if used the right way.