### PR TITLE
Date parser fix

### DIFF
--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -38,6 +38,8 @@ english_fixes = {
 	#	Does not occur in normal use, however if a dictionary entry contains the Mc prefix, and NVDA splits it up, the synth will crash.
 	#	Also fixes ViaVoice, as the parser is more strict there and doesn't like spaces in Mc names.
 		re.compile(r"\b(Mc)\s+([A-Z][a-z]+)"): r"\1\2",
+# Fixes a weird issue with the date parser. Without this fix, strings like "03 Marble" will be pronounced as "march threerd ble".
+		re.compile(r"\b(\d+) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sept|Oct|Nov|Dec)([a-z]+)"): r"\1  \2\3",
 # Crash words, formerly part of anticrash_res.
 	re.compile(r'\b(.*?)c(ae|\xe6)sur(e)?', re.I): r'\1seizur',
 	re.compile(r"\b(|\d+|\W+)h'(r|v)[e]", re.I): r"\1h \2e",

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -40,6 +40,8 @@ english_fixes = {
 		re.compile(r"\b(Mc)\s+([A-Z][a-z]+)"): r"\1\2",
 # Fixes a weird issue with the date parser. Without this fix, strings like "03 Marble" will be pronounced as "march threerd ble".
 		re.compile(r"\b(\d+) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sept|Oct|Nov|Dec)([a-z]+)"): r"\1  \2\3",
+# Don't break UK formatted dates.
+		re.compile(r"\b(\d+)  (January|February|March|April|May|June|July|August|September|October|November|December)"): r"\1 \2",
 # Crash words, formerly part of anticrash_res.
 	re.compile(r'\b(.*?)c(ae|\xe6)sur(e)?', re.I): r'\1seizur',
 	re.compile(r"\b(|\d+|\W+)h'(r|v)[e]", re.I): r"\1h \2e",

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -39,7 +39,7 @@ english_fixes = {
 	#	Also fixes ViaVoice, as the parser is more strict there and doesn't like spaces in Mc names.
 		re.compile(r"\b(Mc)\s+([A-Z][a-z]+)"): r"\1\2",
 # Fixes a weird issue with the date parser. Without this fix, strings like "03 Marble" will be pronounced as "march threerd ble".
-		re.compile(r"\b(\d+) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sept|Oct|Nov|Dec)([a-z]+)"): r"\1  \2\3",
+		re.compile(r"\b(\d+) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)([a-z]+)"): r"\1  \2\3",
 # Don't break UK formatted dates.
 		re.compile(r"\b(\d+)  (January|February|March|April|May|June|July|August|September|October|November|December)"): r"\1 \2",
 # Crash words, formerly part of anticrash_res.


### PR DESCRIPTION
This PR finally fixes the long standing bug with the date parser, so strings like "03 Marble" won't be pronounced as "March Threerd ble". The regex is a bit heavy, but I don't want to catch a legitimate date like 23 Oct. Dates are often formatted this way when viewing email headers, for instance.