### PR TITLE
Send current speech settings toggle

### DIFF
--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -116,7 +116,8 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		BooleanDriverSetting("backquoteVoiceTags", _("Enable backquote voice &tags"), False),
 		BooleanDriverSetting("ABRDICT", _("Enable &abbreviation dictionary"), False),
 		BooleanDriverSetting("phrasePrediction", _("Enable Phrase Prediction"), False),
-		BooleanDriverSetting("shortpause", _("&Shorten Pauses"), False))
+		BooleanDriverSetting("shortpause", _("&Shorten Pauses"), False),
+		BooleanDriverSetting("sendParams", _("Always send current speech settings"), False))
 	supportedCommands = {
 		speech.IndexCommand,
 		speech.CharacterModeCommand,
@@ -249,7 +250,9 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 			embeds+=b"`pp1 "
 		else:
 			embeds+=b"`pp0 "
-		text = b"`vv%d `vs%d %s %s" % (_ibmeci.getVParam(ECIVoiceParam.eciVolume), _ibmeci.getVParam(ECIVoiceParam.eciSpeed), embeds.rstrip(), text) # bring all the printf stuff into one call, in one string. This avoids all the concatonation and printf additions of the previous organization.
+		if self._sendParams:
+			embeds+=b"`vv%d `vs%d " % (_ibmeci.getVParam(ECIVoiceParam.eciVolume), _ibmeci.getVParam(ECIVoiceParam.eciSpeed))
+		text = b"%s %s" % (embeds.rstrip(), text) # bring all the printf stuff into one call, in one string. This avoids all the concatonation and printf additions of the previous organization.
 		return text
 	def pause(self,switch):
 		_ibmeci.pause(switch)
@@ -261,6 +264,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 	_ABRDICT=False
 	_phrasePrediction=False
 	_shortpause=False
+	_sendParams=True
 	def _get_backquoteVoiceTags(self):
 		return self._backquoteVoiceTags
 
@@ -286,6 +290,12 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		if enable == self._shortpause:
 			return
 		self._shortpause = enable
+	def _get_sendParams(self):
+		return self._sendParams
+	def _set_sendParams(self, enable):
+		if enable == self._sendParams:
+			return
+		self._sendParams = enable
 	_rateBoost = False
 	RATE_BOOST_MULTIPLIER = 1.6
 	def _get_rateBoost(self):


### PR DESCRIPTION
This pull request adds a toggle to enable or disable the sending of current volume and speed parameters on every string, mostly useful for ViaVoice, but also Eloquence since sending parameters caused regressions. This is part of a larger project to improve ViaVoice compatibility, fixing a number of issues and adding some newly discovered languages, but this is not ready yet. In the short term, this option will greatly improve ViaVoice usability, since ViaVoice does not ignore v* annotations, pausing slightly every time they're sent, even if parameters aren't actually changed, which makes it quite unusable, since it will pause on every annotation, making it sound like start. Button. Running applications. Tool bar.