### PR TITLE
Another ViaVoice fix

### DIFF
--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -220,8 +220,8 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		if last is not None and last[-1] not in punctuation:
 			# check if a pitch command is at the end of the list, because p1 need to be send before this.
 			# index -2 is because -1 always seem to be an index command.
-			if outlist[-2][0] == _ibmeci.setProsodyParam: outlist.insert(-2, (_ibmeci.speak, (b'`p1. ',)))
-			else: outlist.append((_ibmeci.speak, (b'`p1. ',)))
+			if outlist[-2][0] == _ibmeci.setProsodyParam: outlist.insert(-2, (_ibmeci.speak, (b'`p1 ',)))
+			else: outlist.append((_ibmeci.speak, (b'`p1 ',)))
 		if charmode:
 			outlist.append((_ibmeci.speak, (b"`ts0",)))
 		outlist.append((_ibmeci.setEndStringMark, ()))


### PR DESCRIPTION
Removed the period from the p1s sent in strings so that navigating by word to a string like https:// won't cause the dot to be pronounced in ViaVoice. This doesn't seem to make a difference in the pause length either way, so it can be a global addon change.