### PR TITLE
ViaVoice

### DIFF
--- a/addon/synthDrivers/_ibmeci.py
+++ b/addon/synthDrivers/_ibmeci.py
@@ -109,7 +109,7 @@ vparams = {}
 
 class EciThread(threading.Thread):
 	def run(self):
-		global vparams, params, speaking, endMarkersCount
+		global vparams, params, speaking, endMarkersCount, isIBM
 		global eciThreadId, dll, handle
 		eciThreadId = windll.kernel32.GetCurrentThreadId()
 		msg = wintypes.MSG()

--- a/addon/synthDrivers/_ibmeci.py
+++ b/addon/synthDrivers/_ibmeci.py
@@ -124,6 +124,11 @@ class EciThread(threading.Thread):
 		if v is not None:
 			dictHandles[v[0]]=v[1]
 			dll.eciSetDict(handle,v[1])
+		version=eciVersion()
+		if version>'6.4':
+			isIBM=True
+		else:
+			isIBM=False
 		started.set()
 		while True:
 			user32.GetMessageA(byref(msg), 0, 0, 0)
@@ -392,7 +397,7 @@ def process():
 def eciVersion():
 	ptr=b"       "
 	dll.eciVersion(ptr)
-	return ptr
+	return ptr.decode('ascii')
 
 def getVoiceByLanguage(lang):
 	""" Return the voice corresponding to the given language

--- a/addon/synthDrivers/_ibmeci.py
+++ b/addon/synthDrivers/_ibmeci.py
@@ -186,7 +186,7 @@ def eciCheck():
 #	if path.exists(path.abspath(path.join(path.abspath(path.dirname(__file__)), 'ibmtts'))): ttsPath='ibmtts'
 	if  not path.isabs(ttsPath):
 		ttsPath = path.abspath(path.join(path.abspath(path.dirname(__file__)), ttsPath))
-		if path.exists(ttsPath): iniCheck()
+		if path.exists(ttsPath) and not isIBM: iniCheck()
 	if not path.exists(ttsPath): return False
 	if dll: return True
 	try:

--- a/addon/synthDrivers/_ibmeci.py
+++ b/addon/synthDrivers/_ibmeci.py
@@ -44,6 +44,7 @@ class ECIMessage:
 
 class ECICallbackReturn:
 	eciDataNotProcessed, eciDataProcessed, eciDataAbort= range(3)
+isIBM=False
 
 # constants
 samples=3300
@@ -70,7 +71,11 @@ langs={
 	'deu': (262144, _('German'), 'de_DE', 'de'),
 	'ita': (327680, _('Italian'), 'it_IT', 'it'),
 	'enu': (65536, _('American English'), 'en_US', 'en'),
-	'eng': (65537, _('British English'), 'en_UK', '')
+	'eng': (65537, _('British English'), 'en_UK', ''),
+	'swe': (917504, _('Swedish'), 'sv_SE', 'sv'),
+	'nor': (851968, _('Norwegian'), 'nb_NO', 'nb'),
+	'dan': (983040, _('Danish'), 'da_DK', 'da'),
+	'ctt': (720897, _('Hong Kong Cantonese'), 'yue', '')
 }
 
 audioStream = BytesIO()
@@ -178,7 +183,7 @@ def eciCheck():
 	global ttsPath, dllName, dll
 	dllName = config.conf.profiles[0]['ibmeci']['dllName']
 	ttsPath =  config.conf.profiles[0]['ibmeci']['TTSPath']
-	if path.exists(path.abspath(path.join(path.abspath(path.dirname(__file__)), 'ibmtts'))): ttsPath='ibmtts'
+#	if path.exists(path.abspath(path.join(path.abspath(path.dirname(__file__)), 'ibmtts'))): ttsPath='ibmtts'
 	if  not path.isabs(ttsPath):
 		ttsPath = path.abspath(path.join(path.abspath(path.dirname(__file__)), ttsPath))
 		if path.exists(ttsPath): iniCheck()

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -57,7 +57,7 @@ english_fixes = {
 	re.compile(r"(\d+)([\-\+\*\^\/]+)(\d+)([\-\+\*\^\/]*)([\.\,])(0{2,})", re.I): r"\1\2\3\4 \5\6",
 	re.compile(r"(\d+)(\.+)(\d+)(\.+)(0{2,})([\+\-\/\*\^])", re.I): r"\1\2\3\4 \5\6",
 	# Crash words, formerly part of anticrash_res.
-	re.compile(r'\b(.*?)c(ae|\xe6)s[uū]r(e)?', re.I): r'\1seizur',
+	re.compile(r'\b(.*?)c(ae|\xe6)sur(e)?', re.I): r'\1seizur',
 	re.compile(r"\b(|\d+|\W+)h'(r|v)[e]", re.I): r"\1h \2e",
 	re.compile(r"\b(\w+[bdfhjlmnqrvz])(h[he]s)([abcdefghjklmnopqrstvwy]\w+)\b", re.I): r"\1 \2\3",
 	re.compile(r"\b(\w+[bdfhjlmnqrvz])(h[he]s)(iron+[degins]?)", re.I): r"\1 \2\3",

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -269,7 +269,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		if _ibmeci.params[9] in (131072,  131073) and not _ibmeci.isIBM: text = resub(spanish_fixes, text)
 		if _ibmeci.params[9] in ('esp', 131072) and _ibmeci.isIBM: text = resub(spanish_ibm_fixes, text)
 		if _ibmeci.params[9] in (196609, 196608):
-			text = text.replace('quil', 'qil') #Sometimes this string make everything buggy with IBMTTS in French
+			text = text.replace(br'quil', br'qil') #Sometimes this string make everything buggy with IBMTTS in French
 		if  _ibmeci.params[9] in ('deu', 262144):
 			text = resub(german_fixes, text)
 		if  _ibmeci.params[9] in ('ptb', 458752) and _ibmeci.isIBM:

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -38,24 +38,9 @@ english_fixes = {
 	#	Also fixes ViaVoice, as the parser is more strict there and doesn't like spaces in Mc names.
 	re.compile(r"\b(Mc)\s+([A-Z][a-z]+)"): r"\1\2",
 # Fixes a weird issue with the date parser. Without this fix, strings like "03 Marble" will be pronounced as "march threerd ble".
-#	re.compile(r"\b(\d+) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)([a-z]+)"): r"\1  \2\3",
+	re.compile(r"\b(\d+) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)([a-z]+)"): r"\1  \2\3",
 	# Don't break UK formatted dates.
-#	re.compile(r"\b(\d+)  (January|February|March|April|May|June|July|August|September|October|November|December)\b"): r"\1 \2",
-	#ViaVoice specific fixes
-	#Prevents the synth from spelling out everything if a punctuation mark follows a word.
-	re.compile(r"([a-z]+)([\~\#\$\%\^\*\(\{\|\[\<\%\•])", re.I): r"\1 \2",
-	#Don't break phrases like books).
-	re.compile(r"([a-z]+)\s+(\(s\))", re.I): r"\1\2",
-	#Adds support for spaced parentheses.
-	re.compile(r"(\(+)\s+([a-z]+)\s+(\)+)", re.I): r"\1\2\3",
-	#Removes spaces if a string is followed by a punctuation mark, since ViaVoice doesn't tolerate that.
-	re.compile(r"([a-z]+|\d+|\W+)\s+([:.!;,])", re.I): r"\1\2",
-	#ViaVoice specific crash words
-	re.compile(r"(http://|ftp://)([a-z]+)(\W){1,3}([a-z]+)(/*\W){1,3}([a-z]){1}", re.I): r"\1\2\3\4 \5\6",
-	re.compile(r"(\d+)([\+\-\*\^\/])(\d+)(\.)(\d+)(\.)(0{2,})", re.I): r"\1\2\3\4\5\6 \7",
-	re.compile(r"(\d+)([\+\-\*\^\/])(\d+)(\.)(\d+)(\.)(0\W)", re.I): r"\1\2\3\4 \5\6\7",
-	re.compile(r"(\d+)([\-\+\*\^\/]+)(\d+)([\-\+\*\^\/]*)([\.\,])(0{2,})", re.I): r"\1\2\3\4 \5\6",
-	re.compile(r"(\d+)(\.+)(\d+)(\.+)(0{2,})([\+\-\/\*\^])", re.I): r"\1\2\3\4 \5\6",
+	re.compile(r"\b(\d+)  (January|February|March|April|May|June|July|August|September|October|November|December)\b"): r"\1 \2",
 	# Crash words, formerly part of anticrash_res.
 	re.compile(r'\b(.*?)c(ae|\xe6)sur(e)?', re.I): r'\1seizur',
 	re.compile(r"\b(|\d+|\W+)h'(r|v)[e]", re.I): r"\1h \2e",
@@ -71,7 +56,21 @@ english_fixes = {
 	re.compile(r"\b(\d+|\W+)?(\w+\_+)?(\_+)?([bcdfghjklmnpqrstvwxz]+)?(\d+)?t+z[s]che", re.I): r"\1 \2 \3 \4 \5 tz sche",
 	re.compile(r"\b(juar[aeou]s)([aeiou]{6,})", re.I): r"\1 \2"
 }
-
+english_ibm_fixes = {
+	#Prevents the synth from spelling out everything if a punctuation mark follows a word.
+	re.compile(r"([a-z]+)([\~\#\$\%\^\*\(\{\|\[\<\%\•])", re.I): r"\1 \2",
+	#Don't break phrases like books).
+	re.compile(r"([a-z]+)\s+(\(s\))", re.I): r"\1\2",
+	#Adds support for spaced parentheses.
+	re.compile(r"(\(+)\s+([a-z]+)\s+(\)+)", re.I): r"\1\2\3",
+	#Removes spaces if a string is followed by a punctuation mark, since ViaVoice doesn't tolerate that.
+	re.compile(r"([a-z]+|\d+|\W+)\s+([:.!;,])", re.I): r"\1\2",
+	re.compile(r"(http://|ftp://)([a-z]+)(\W){1,3}([a-z]+)(/*\W){1,3}([a-z]){1}", re.I): r"\1\2\3\4 \5\6",
+	re.compile(r"(\d+)([\+\-\*\^\/])(\d+)(\.)(\d+)(\.)(0{2,})", re.I): r"\1\2\3\4\5\6 \7",
+	re.compile(r"(\d+)([\+\-\*\^\/])(\d+)(\.)(\d+)(\.)(0\W)", re.I): r"\1\2\3\4 \5\6\7",
+	re.compile(r"(\d+)([\-\+\*\^\/]+)(\d+)([\-\+\*\^\/]*)([\.\,])(0{2,})", re.I): r"\1\2\3\4 \5\6",
+	re.compile(r"(\d+)(\.+)(\d+)(\.+)(0{2,})([\+\-\/\*\^])", re.I): r"\1\2\3\4 \5\6",
+}
 spanish_fixes = {
 	re.compile(u'([€$]\d{1,3})((\s\d{3})+\.\d{2})'): r'\1 \2',
 }
@@ -263,6 +262,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 	def processText(self,text):
 		text = text.rstrip()
 		if _ibmeci.params[9] in (65536, 65537, 393216, 655360, 720897): text = resub(english_fixes, text) #Applies to all languages with dual language support.
+		if _ibmeci.params[9] in (65536, 65537, 393216, 655360, 720897) and _ibmeci.isIBM: text = resub(english_ibm_fixes, text)
 		if _ibmeci.params[9] in (131072,  131073) and not _ibmeci.isIBM: text = resub(spanish_fixes, text)
 		if _ibmeci.params[9] in ('esp', 131072) and _ibmeci.isIBM: text = resub(spanish_ibm_fixes, text)
 		if _ibmeci.params[9] in (196609, 196608):

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -58,7 +58,7 @@ english_fixes = {
 }
 english_ibm_fixes = {
 	#Prevents the synth from spelling out everything if a punctuation mark follows a word.
-	re.compile(br"([a-z]+)([\x7e\x23\x24\x25\x5e\x2a\x28\x7b\x7c\x5c\x5b\x3c\x25\x2022])", re.I): br"\1 \2",
+	re.compile(br"([a-z]+)([\x7e\x23\x24\x25\x5e\x2a\x28\x7b\x7c\x5c\x5b\x3c\x25\x95])", re.I): br"\1 \2",
 	#Don't break phrases like books).
 	re.compile(br"([a-z]+)\s+(\(s\))", re.I): br"\1\2",
 	#Adds support for spaced parentheses.

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -68,6 +68,7 @@ english_ibm_fixes = {
 	re.compile(br"(http://|ftp://)([a-z]+)(\W){1,3}([a-z]+)(/*\W){1,3}([a-z]){1}", re.I): br"\1\2\3\4 \5\6",
 	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f])(\d+)(\.)(\d+)(\.)(0{2,})", re.I): br"\1\2\3\4\5\6 \7",
 	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f])(\d+)(\.)(\d+)(\.)(0\W)", re.I): br"\1\2\3\4 \5\6\7",
+	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f]+)(\d+)([\x2d\x2b\x2a\x5e\x2f]+)([\x2c\x2e+])(0{2,})", re.I): br"\1\2\3\4\5 \6",
 	re.compile(br"(\d+)(\.+)(\d+)(\.+)(0{2,})([\x2d\x2b\x2a\x5e\x2f])", re.I): br"\1\2\3\4 \5\6",
 }
 spanish_fixes = {

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -68,7 +68,6 @@ english_ibm_fixes = {
 	re.compile(br"(http://|ftp://)([a-z]+)(\W){1,3}([a-z]+)(/*\W){1,3}([a-z]){1}", re.I): br"\1\2\3\4 \5\6",
 	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f])(\d+)(\.)(\d+)(\.)(0{2,})", re.I): br"\1\2\3\4\5\6 \7",
 	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f])(\d+)(\.)(\d+)(\.)(0\W)", re.I): br"\1\2\3\4 \5\6\7",
-	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f]+)(\d+)([\x2d\x2b\x2a\x5e\x2f]*)([\.\,])(0{2,})", re.I): br"\1\2\3\4 \5\6",
 	re.compile(br"(\d+)(\.+)(\d+)(\.+)(0{2,})([\x2d\x2b\x2a\x5e\x2f])", re.I): br"\1\2\3\4 \5\6",
 }
 spanish_fixes = {

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -83,6 +83,9 @@ german_fixes = {
 	re.compile(r'dane-ben', re.I): r'dane- ben',
 	re.compile(r'dage-gen', re.I): r'dage- gen',
 }
+portuguese_ibm_fixes = {
+	re.compile(r'(\d{1,2}):(00):(\d{1,2})'): r'\1:\2 \3',
+}
 
 # fixme: These are only the variant names for enu. Does ECI have a way to obtain names for other languages?
 variants = {
@@ -263,6 +266,8 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 			text = text.replace('quil', 'qil') #Sometimes this string make everything buggy with IBMTTS in French
 		if  _ibmeci.params[9] in ('deu', 262144):
 			text = resub(german_fixes, text)
+		if  _ibmeci.params[9] in ('ptb', 458752) and _ibmeci.isIBM:
+			text = resub(portuguese_ibm_fixes, text)
 		#this converts to ansi for anticrash. If this breaks with foreign langs, we can remove it.
 		text = text.encode(self.currentEncoding, 'replace') # special unicode symbols may encode to backquote. For this reason, backquote processing is after this.
 		if not self._backquoteVoiceTags:

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -31,7 +31,7 @@ minRate=40
 maxRate=156
 punctuation = b"-,.:;)(?!\x96\x97"
 pause_re = re.compile(br'([a-zA-Z0-9]|\s)([%s])(\2*?)(\s|[\\/]|$)' %punctuation)
-#time_re = re.compile(br"(\d):(\d+):(\d+)")
+time_re = re.compile(br"(\d):(\d+):(\d+)")
 
 english_fixes = {
 	#	Does not occur in normal use, however if a dictionary entry contains the Mc prefix, and NVDA splits it up, the synth will crash.
@@ -269,7 +269,8 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 			text=text.replace(b'`', b' ') # no embedded commands
 		if self._shortpause:
 			text = pause_re.sub(br'\1 `p1\2\3\4', text) # this enforces short, JAWS-like pauses.
-#		text = time_re.sub(br'\1:\2 \3', text) # apparently if this isn't done strings like 2:30:15 will only announce 2:30
+		if not _ibmeci.isIBM:
+			text = time_re.sub(br'\1:\2 \3', text) # apparently if this isn't done strings like 2:30:15 will only announce 2:30
 		embeds=b''
 		if self._ABRDICT:
 			embeds+=b"`da1 "

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -262,7 +262,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 
 	def processText(self,text):
 		text = text.rstrip()
-		if _ibmeci.params[9] in (65536, 65537, 393216, 655360): text = resub(english_fixes, text) #Applies to Chinese and Korean as they can read English text and thus inherit the English bugs.
+		if _ibmeci.params[9] in (65536, 65537, 393216, 655360, 720897): text = resub(english_fixes, text) #Applies to all languages with dual language support.
 		if _ibmeci.params[9] in (131072,  131073) and not _ibmeci.isIBM: text = resub(spanish_fixes, text)
 		if _ibmeci.params[9] in ('esp', 131072) and _ibmeci.isIBM: text = resub(spanish_ibm_fixes, text)
 		if _ibmeci.params[9] in (196609, 196608):

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -61,8 +61,6 @@ english_ibm_fixes = {
 	re.compile(br"([a-z]+)([\x7e\x23\x24\x25\x5e\x2a\x28\x7b\x7c\x5c\x5b\x3c\x25\x95])", re.I): br"\1 \2",
 	#Don't break phrases like books).
 	re.compile(br"([a-z]+)\s+(\(s\))", re.I): br"\1\2",
-	#Adds support for spaced parentheses.
-	re.compile(br"(\(+)\s+([a-z]+)\s+(\)+)", re.I): br"\1\2\3",
 	#Removes spaces if a string is followed by a punctuation mark, since ViaVoice doesn't tolerate that.
 	re.compile(br"([a-z]+|\d+|\W+)\s+([\x3a\x2e\x21\x3b\x2c])", re.I): br"\1\2",
 	re.compile(br"(http://|ftp://)([a-z]+)(\W){1,3}([a-z]+)(/*\W){1,3}([a-z]){1}", re.I): br"\1\2\3\4 \5\6",

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -74,6 +74,8 @@ english_fixes = {
 
 spanish_fixes = {
 	re.compile(u'([€$]\d{1,3})((\s\d{3})+\.\d{2})'): r'\1 \2',
+}
+spanish_ibm_fixes = {
 	#ViaVoice's time parser is slightly broken in Spanish, and will crash if the minute part goes from 20 to 59.
 	#For these times, convert the periods to colons.
 	re.compile(r'([0-2][0-4])\.([2-5][0-9])\.([0-5][0-9])'): r'\1:\2:\3',
@@ -261,7 +263,8 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 	def processText(self,text):
 		text = text.rstrip()
 		if _ibmeci.params[9] in (65536, 65537, 393216, 655360): text = resub(english_fixes, text) #Applies to Chinese and Korean as they can read English text and thus inherit the English bugs.
-		if _ibmeci.params[9] in (131072,  131073): text = resub(spanish_fixes, text)
+		if _ibmeci.params[9] in (131072,  131073) and not _ibmeci.isIBM: text = resub(spanish_fixes, text)
+		if _ibmeci.params[9] in ('esp', 131072) and _ibmeci.isIBM: text = resub(spanish_ibm_fixes, text)
 		if _ibmeci.params[9] in (196609, 196608):
 			text = text.replace('quil', 'qil') #Sometimes this string make everything buggy with IBMTTS in French
 		if  _ibmeci.params[9] in ('deu', 262144):

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -68,6 +68,7 @@ english_ibm_fixes = {
 	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f])(\d+)(\.)(\d+)(\.)(0\W)", re.I): br"\1\2\3\4 \5\6\7",
 	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f]+)(\d+)([\x2d\x2b\x2a\x5e\x2f]+)([\x2c\x2e+])(0{2,})", re.I): br"\1\2\3\4\5 \6",
 	re.compile(br"(\d+)(\.+)(\d+)(\.+)(0{2,})\s*\.*([\x2d\x2b\x2a\x5e\x2f])", re.I): br"\1\2\3\4 \5\6",
+	re.compile(br"(\d+)\s*([\x2d\x2b\x2a\x5e\x2f])\s*(\d+)(,)(0{2,})", re.I): br"\1\2\3\4 \5",
 }
 spanish_fixes = {
 	# Euros

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -36,56 +36,57 @@ time_re = re.compile(br"(\d):(\d+):(\d+)")
 english_fixes = {
 	#	Does not occur in normal use, however if a dictionary entry contains the Mc prefix, and NVDA splits it up, the synth will crash.
 	#	Also fixes ViaVoice, as the parser is more strict there and doesn't like spaces in Mc names.
-	re.compile(r"\b(Mc)\s+([A-Z][a-z]+)"): r"\1\2",
-# Fixes a weird issue with the date parser. Without this fix, strings like "03 Marble" will be pronounced as "march threerd ble".
-	re.compile(r"\b(\d+) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)([a-z]+)"): r"\1  \2\3",
+	re.compile(br"\b(Mc)\s+([A-Z][a-z]+)"): br"\1\2",
+	# Fixes a weird issue with the date parser. Without this fix, strings like "03 Marble" will be pronounced as "march threerd ble".
+	re.compile(br"\b(\d+) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)([a-z]+)"): br"\1  \2\3",
 	# Don't break UK formatted dates.
-	re.compile(r"\b(\d+)  (January|February|March|April|May|June|July|August|September|October|November|December)\b"): r"\1 \2",
+	re.compile(br"\b(\d+)  (January|February|March|April|May|June|July|August|September|October|November|December)\b"): br"\1 \2",
 	# Crash words, formerly part of anticrash_res.
-	re.compile(r'\b(.*?)c(ae|\xe6)sur(e)?', re.I): r'\1seizur',
-	re.compile(r"\b(|\d+|\W+)h'(r|v)[e]", re.I): r"\1h \2e",
-	re.compile(r"\b(\w+[bdfhjlmnqrvz])(h[he]s)([abcdefghjklmnopqrstvwy]\w+)\b", re.I): r"\1 \2\3",
-	re.compile(r"\b(\w+[bdfhjlmnqrvz])(h[he]s)(iron+[degins]?)", re.I): r"\1 \2\3",
-	re.compile(r"\b(\w+'{1,}[bcdfghjklmnpqrstvwxz])'*(h+[he]s)([abcdefghijklmnopqrstvwy]\w+)\b", re.I): r"\1 \2\3",
-	re.compile(r"\b(\w+[bcdfghjklmnpqrstvwxz])('{1,}h+[he]s)([abcdefghijklmnopqrstvwy]\w+)\b", re.I): r"\1 \2\3",
-	re.compile(r"(\d):(\d\d[snrt][tdh])", re.I): r"\1 \2",
-	re.compile(r"\b([bcdfghjklmnpqrstvwxz]+)'([bcdefghjklmnpqrstvwxz']+)'([drtv][aeiou]?)", re.I): r"\1 \2 \3",
-	re.compile(r"\b(you+)'(re)+'([drv]e?)", re.I): r"\1 \2 \3",
-	re.compile(r"(re|un|non|anti)cosp", re.I): r"\1kosp",
-	re.compile(r"(EUR[A-Z]+)(\d+)", re.I): r"\1 \2",
-	re.compile(r"\b(\d+|\W+)?(\w+\_+)?(\_+)?([bcdfghjklmnpqrstvwxz]+)?(\d+)?t+z[s]che", re.I): r"\1 \2 \3 \4 \5 tz sche",
-	re.compile(r"\b(juar[aeou]s)([aeiou]{6,})", re.I): r"\1 \2"
+	re.compile(br'\b(.*?)c(ae|\xe6)sur(e)?', re.I): br'\1seizur',
+	re.compile(br"\b(|\d+|\W+)h'(r|v)[e]", re.I): br"\1h \2e",
+	re.compile(br"\b(\w+[bdfhjlmnqrvz])(h[he]s)([abcdefghjklmnopqrstvwy]\w+)\b", re.I): br"\1 \2\3",
+	re.compile(br"\b(\w+[bdfhjlmnqrvz])(h[he]s)(iron+[degins]?)", re.I): br"\1 \2\3",
+	re.compile(br"\b(\w+'{1,}[bcdfghjklmnpqrstvwxz])'*(h+[he]s)([abcdefghijklmnopqrstvwy]\w+)\b", re.I): br"\1 \2\3",
+	re.compile(br"\b(\w+[bcdfghjklmnpqrstvwxz])('{1,}h+[he]s)([abcdefghijklmnopqrstvwy]\w+)\b", re.I): br"\1 \2\3",
+	re.compile(br"(\d):(\d\d[snrt][tdh])", re.I): br"\1 \2",
+	re.compile(br"\b([bcdfghjklmnpqrstvwxz]+)'([bcdefghjklmnpqrstvwxz']+)'([drtv][aeiou]?)", re.I): br"\1 \2 \3",
+	re.compile(br"\b(you+)'(re)+'([drv]e?)", re.I): br"\1 \2 \3",
+	re.compile(br"(re|un|non|anti)cosp", re.I): br"\1kosp",
+	re.compile(br"(EUR[A-Z]+)(\d+)", re.I): br"\1 \2",
+	re.compile(br"\b(\d+|\W+)?(\w+\_+)?(\_+)?([bcdfghjklmnpqrstvwxz]+)?(\d+)?t+z[s]che", re.I): br"\1 \2 \3 \4 \5 tz sche",
+	re.compile(br"\b(juar[aeou]s)([aeiou]{6,})", re.I): br"\1 \2"
 }
 english_ibm_fixes = {
 	#Prevents the synth from spelling out everything if a punctuation mark follows a word.
-	re.compile(r"([a-z]+)([\~\#\$\%\^\*\(\{\|\[\<\%\•])", re.I): r"\1 \2",
+	re.compile(br"([a-z]+)([\x7e\x23\x24\x25\x5e\x2a\x28\x7b\x7c\x5c\x5b\x3c\x25\x2022])", re.I): br"\1 \2",
 	#Don't break phrases like books).
-	re.compile(r"([a-z]+)\s+(\(s\))", re.I): r"\1\2",
+	re.compile(br"([a-z]+)\s+(\(s\))", re.I): br"\1\2",
 	#Adds support for spaced parentheses.
-	re.compile(r"(\(+)\s+([a-z]+)\s+(\)+)", re.I): r"\1\2\3",
+	re.compile(br"(\(+)\s+([a-z]+)\s+(\)+)", re.I): br"\1\2\3",
 	#Removes spaces if a string is followed by a punctuation mark, since ViaVoice doesn't tolerate that.
-	re.compile(r"([a-z]+|\d+|\W+)\s+([:.!;,])", re.I): r"\1\2",
-	re.compile(r"(http://|ftp://)([a-z]+)(\W){1,3}([a-z]+)(/*\W){1,3}([a-z]){1}", re.I): r"\1\2\3\4 \5\6",
-	re.compile(r"(\d+)([\+\-\*\^\/])(\d+)(\.)(\d+)(\.)(0{2,})", re.I): r"\1\2\3\4\5\6 \7",
-	re.compile(r"(\d+)([\+\-\*\^\/])(\d+)(\.)(\d+)(\.)(0\W)", re.I): r"\1\2\3\4 \5\6\7",
-	re.compile(r"(\d+)([\-\+\*\^\/]+)(\d+)([\-\+\*\^\/]*)([\.\,])(0{2,})", re.I): r"\1\2\3\4 \5\6",
-	re.compile(r"(\d+)(\.+)(\d+)(\.+)(0{2,})([\+\-\/\*\^])", re.I): r"\1\2\3\4 \5\6",
+	re.compile(br"([a-z]+|\d+|\W+)\s+([\x3a\x2e\x21\x3b\x2c])", re.I): br"\1\2",
+	re.compile(br"(http://|ftp://)([a-z]+)(\W){1,3}([a-z]+)(/*\W){1,3}([a-z]){1}", re.I): br"\1\2\3\4 \5\6",
+	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f])(\d+)(\.)(\d+)(\.)(0{2,})", re.I): br"\1\2\3\4\5\6 \7",
+	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f])(\d+)(\.)(\d+)(\.)(0\W)", re.I): br"\1\2\3\4 \5\6\7",
+	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f]+)(\d+)([\x2d\x2b\x2a\x5e\x2f]*)([\.\,])(0{2,})", re.I): br"\1\2\3\4 \5\6",
+	re.compile(br"(\d+)(\.+)(\d+)(\.+)(0{2,})([\x2d\x2b\x2a\x5e\x2f])", re.I): br"\1\2\3\4 \5\6",
 }
 spanish_fixes = {
-	re.compile(u'([€$]\d{1,3})((\s\d{3})+\.\d{2})'): r'\1 \2',
+	# Euros
+	re.compile(b'([\x80$]\\d{1,3})((\\s\\d{3})+\\.\\d{2})'): r'\1 \2',
 }
 spanish_ibm_fixes = {
 	#ViaVoice's time parser is slightly broken in Spanish, and will crash if the minute part goes from 20 to 59.
 	#For these times, convert the periods to colons.
-	re.compile(r'([0-2][0-4])\.([2-5][0-9])\.([0-5][0-9])'): r'\1:\2:\3',
+	re.compile(br'([0-2][0-4])\.([2-5][0-9])\.([0-5][0-9])'): br'\1:\2:\3',
 }
 german_fixes = {
 # Crash words.
-	re.compile(r'dane-ben', re.I): r'dane- ben',
-	re.compile(r'dage-gen', re.I): r'dage- gen',
+	re.compile(br'dane-ben', re.I): br'dane- ben',
+	re.compile(br'dage-gen', re.I): br'dage- gen',
 }
 portuguese_ibm_fixes = {
-	re.compile(r'(\d{1,2}):(00):(\d{1,2})'): r'\1:\2 \3',
+	re.compile(br'(\d{1,2}):(00):(\d{1,2})'): br'\1:\2 \3',
 }
 
 # fixme: These are only the variant names for enu. Does ECI have a way to obtain names for other languages?
@@ -260,6 +261,8 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		_ibmeci.process()
 
 	def processText(self,text):
+		#this converts to ansi for anticrash. If this breaks with foreign langs, we can remove it.
+		text = text.encode(self.currentEncoding, 'replace') # special unicode symbols may encode to backquote. For this reason, backquote processing is after this.
 		text = text.rstrip()
 		if _ibmeci.params[9] in (65536, 65537, 393216, 655360, 720897): text = resub(english_fixes, text) #Applies to all languages with dual language support.
 		if _ibmeci.params[9] in (65536, 65537, 393216, 655360, 720897) and _ibmeci.isIBM: text = resub(english_ibm_fixes, text)
@@ -271,8 +274,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 			text = resub(german_fixes, text)
 		if  _ibmeci.params[9] in ('ptb', 458752) and _ibmeci.isIBM:
 			text = resub(portuguese_ibm_fixes, text)
-		#this converts to ansi for anticrash. If this breaks with foreign langs, we can remove it.
-		text = text.encode(self.currentEncoding, 'replace') # special unicode symbols may encode to backquote. For this reason, backquote processing is after this.
 		if not self._backquoteVoiceTags:
 			text=text.replace(b'`', b' ') # no embedded commands
 		if self._shortpause:

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -69,7 +69,7 @@ english_ibm_fixes = {
 	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f])(\d+)(\.)(\d+)(\.)(0{2,})", re.I): br"\1\2\3\4\5\6 \7",
 	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f])(\d+)(\.)(\d+)(\.)(0\W)", re.I): br"\1\2\3\4 \5\6\7",
 	re.compile(br"(\d+)([\x2d\x2b\x2a\x5e\x2f]+)(\d+)([\x2d\x2b\x2a\x5e\x2f]+)([\x2c\x2e+])(0{2,})", re.I): br"\1\2\3\4\5 \6",
-	re.compile(br"(\d+)(\.+)(\d+)(\.+)(0{2,})([\x2d\x2b\x2a\x5e\x2f])", re.I): br"\1\2\3\4 \5\6",
+	re.compile(br"(\d+)(\.+)(\d+)(\.+)(0{2,})\s*\.*([\x2d\x2b\x2a\x5e\x2f])", re.I): br"\1\2\3\4 \5\6",
 }
 spanish_fixes = {
 	# Euros


### PR DESCRIPTION
This pull request improves ViaVoice compatibility. Currently a preview and not ready to be merged, but feel free to provide comments and suggestions.
### New features.
Adds support for Danish, Swedish, Norwegian, and Hong Kong Cantonese languages.
### Fixes.
Adds a number of ViaVoice specific expressions to fix issues, such as words being spelled out if certain punctuation marks follow them, and some ViaVoice specific crash words.
### Todo.
Figure out how to parse the version string. There is currently an unused isIBM variable, and I was thinking of making the addon change its behavior based on it. For example if isIBM was set to true, it could enable the ViaVoice fixes, or disable unneeded aspects such as time_re and iniCheck, and enable them if isIBM was set to False. This probably also necessitates splitting up the English fixes and other parts of the code quite a bit. The isIBM work is now complete, only the parsing of the version string is left to finish.
### Long term.
Probably won't be done in this PR.
Additional things could be tied to isIBM, such as hiding or showing a sample rate option, or adding or removing support for speech.PhonemeCommand. In ViaVoice, there is a 22 kHz mode, and 8 kHz gives you access to a completely different set of voices, and in ViaVoice 6.7 and newer, IPA is supported. However, for IPA support we'd need to figure out how to encode text, or convert IPA to HTML entedies, because while it does accept UTF8, certain symbols such as the em dash still don't encode properly. We'd also need to limit it to 6.7 and newer only.
### Known issues.
* Hong Kong Cantonese does not currently work with automatic language switching. I'm currently using 'yue,' which is apparently the language code, but you have to actually switch to it for characters to read properly, as it's not a supported NVDA language.
* In ViaVoice, text is being  cut off in certain languages. I'm not sure why. Perhaps a buffer somewhere is too small? For example, in Danish, phrases like 13 kg are broken, and in English, reading some long regular expressions causes issues as well. It shouldn't be much of an issue in day to day use, though.
