### PR TITLE
French

### DIFF
--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -237,7 +237,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		if _ibmeci.params[9] in (65536, 65537, 393216, 655360): text = resub(english_fixes, text) #Applies to Chinese and Korean as they can read English text and thus inherit the English bugs.
 		if _ibmeci.params[9] in (131072,  131073): text = resub(spanish_fixes, text)
 		if _ibmeci.params[9] in (196609, 196608):
-			text = text.replace('quil', 'qil') #Sometimes this string make everything buggy with IBMTTS in French
+			text = text.replace(br'quil', br'qil') #Sometimes this string make everything buggy with IBMTTS in French
 		if  _ibmeci.params[9] in ('deu', 262144):
 			text = resub(german_fixes, text)
 		if not self._backquoteVoiceTags:


### PR DESCRIPTION
Fixes an issue in French. While language fixes were being converted to bytes, the French string replacement was missed, making it unusable.