### PR TITLE
Fixes

### DIFF
--- a/addon/synthDrivers/_ibmeci.py
+++ b/addon/synthDrivers/_ibmeci.py
@@ -163,6 +163,7 @@ class EciThread(threading.Thread):
 				param_event.set()
 			elif msg.message == WM_KILL:
 				dll.eciDelete(handle)
+				dictHandles.clear()
 				stopped.set()
 				break
 			else:

--- a/addon/synthDrivers/_ibmeci.py
+++ b/addon/synthDrivers/_ibmeci.py
@@ -363,7 +363,9 @@ def terminate():
 	callbackQueue= callbackThread= dll= eciQueue=eciThread= handle= idleTimer= onDoneSpeaking= onIndexReached= player = None
 
 def setVoice(vl):
-		user32.PostThreadMessageA(eciThreadId, WM_PARAM, vl, ECIParam.eciLanguageDialect)
+	user32.PostThreadMessageA(eciThreadId, WM_PARAM, vl, ECIParam.eciLanguageDialect)
+	param_event.wait()
+	param_event.clear()
 
 def getVParam(pr):
 	return vparams[pr]


### PR DESCRIPTION
* Fixed an issue where the synth would sometimes insist on switching to the wrong language when it was reloaded with NVDA+CTRL+s, or it would take a while to catch up to the currently selected language when automatic language switching was enabled. You may need to re-save your configuration to get this to work properly.
* Dictionary handles are now cleared on exit, which fixes an issue where if the synth was reloaded with NVDA+CTRL+s, dictionaries for non-English languages would no longer load until NVDA was restarted.