### PR TITLE
Locale fixes

### DIFF
--- a/addon/synthDrivers/_ibmeci.py
+++ b/addon/synthDrivers/_ibmeci.py
@@ -59,7 +59,7 @@ WM_INDEX=1032
 
 langs={
 	'esp': (131072, _('Castilian Spanish'), 'es_ES', 'es'),
-	'esm': (131073, _('Latin American Spanish'), 'es_ME', 'es_CO'),
+	'esm': (131073, _('Latin American Spanish'), 'es_MX', 'es_CO'),
 	'ptb': (458752, _('Brazilian Portuguese'), 'pt_BR', 'pt'),
 	'fra': (196608, _('French'), 'fr_FR', 'fr'),
 	'frc': (196609, _('French Canadian'), 'fr_CA', ''),

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -98,7 +98,6 @@ langsAnnotations={
 	"zh_CN":b"`l6.0",
 	"pt":b"`l7",
 	"pt_BR":b"`l7.0",
-	"pt_PT":b"`l7.1",
 	"ja":b"`l8",
 	"ja_JP":b"`l8.0",
 	"ko":b"`l10",

--- a/addon/synthDrivers/ibmeci.py
+++ b/addon/synthDrivers/ibmeci.py
@@ -86,7 +86,7 @@ langsAnnotations={
 	"en_GB":b"`l1.1",
 	"es":b"`l2",
 	"es_ES":b"`l2.0",
-	"es_ME":b"`l2.1",
+	"es_MX":b"`l2.1",
 	"fr":b"`l3",
 	"fr_FR":b"`l3.0",
 	"fr_CA":b"`l3.1",


### PR DESCRIPTION
* Fixed Latin American Spanish locale. The code most often used on web pages and listed in the ISO-639 language tables I've found is es_MX, not es_ME.
* Removed nonexistent pt_PT locale. As far as I know, there was never a Portugal Portuguese dialect of IBMTTS, and because it's listed, every time text with that locale is encountered, the addon will attempt to send an annotation for a language that doesn't exist.